### PR TITLE
Add while loops

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -278,6 +278,27 @@ func (i *IfExpression) String() string {
 	return out.String()
 }
 
+type WhileExpression struct {
+	Token     token.Token // `while` token
+	Condition Expression
+	Body      *BlockStatement
+}
+
+func (w *WhileExpression) expressionNode() {}
+
+func (w *WhileExpression) TokenLiteral() string {
+	return w.Token.Literal
+}
+
+func (w *WhileExpression) String() string {
+	var out bytes.Buffer
+	out.WriteString("while")
+	out.WriteString(w.Condition.String())
+	out.WriteString(" ")
+	out.WriteString(w.Body.String())
+	return out.String()
+}
+
 type CallExpression struct {
 	Token     token.Token // `(` token
 	Function  Expression  // Identifier or Function Literal

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -1,7 +1,7 @@
 package evaluator
 
 import (
-	"log"
+	"fmt"
 	"monkey-pl/object"
 )
 
@@ -35,7 +35,7 @@ var builtins = map[string]*object.Builtin{
 // Called `puts` in the book.
 func print(args ...object.Object) object.Object {
 	for _, arg := range args {
-		log.Println(arg.Inspect())
+		fmt.Println(arg.Inspect())
 	}
 	return NULL
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -94,6 +94,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalBlockStatement(node, env)
 	case *ast.IfExpression:
 		return evalIfExpression(node, env)
+	case *ast.WhileExpression:
+		return evalWhileExpression(node, env)
 	case *ast.ReturnStatement:
 		value := Eval(node.ReturnValue, env)
 		if isError(value) {
@@ -288,6 +290,26 @@ func evalIfExpression(expr *ast.IfExpression, env *object.Environment) object.Ob
 	} else {
 		return NULL
 	}
+}
+
+func evalWhileExpression(expr *ast.WhileExpression, env *object.Environment) object.Object {
+	condition := Eval(expr.Condition, env)
+	iterCount := 0
+	if isError(condition) {
+		return condition
+	}
+	for isTruthy(condition) && iterCount < 1000 {
+		Eval(expr.Body, env)
+		iterCount++
+		condition = Eval(expr.Condition, env)
+	}
+	if iterCount >= 1000 {
+		return newError("maximum iteration count exceeded")
+	}
+	// It would have arguably been more idiomatic to return the result of the final eval call
+	// here. In this case you could assign variables to the result of `while` (you can still do
+	// this but they will always end up NULL). I chose not to do this though.
+	return NULL
 }
 
 func evalBangOperatorExpression(right object.Object) object.Object {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -226,6 +226,14 @@ func TestErrorHandling(t *testing.T) {
 			`let f = fn(x) { x; }; { f: "Monkey" };`,
 			"unhashable object used as a hash key: FUNCTION",
 		},
+		{
+			`let func = fn(x) { func(x + 1); }; func(1);`,
+			"maximum stack depth exceeded",
+		},
+		{
+			`while (true) { x; };`,
+			"maximum iteration count exceeded",
+		},
 	}
 
 	for _, tc := range tests {
@@ -491,6 +499,19 @@ func TestHashIndexExpressions(t *testing.T) {
 		} else {
 			testNullObject(t, evaluated)
 		}
+	}
+}
+
+func TestWhileExpression(t *testing.T) {
+	input := `let i = 0; while (i < 10) { let i = i + 1; }; i;`
+	evaluated := testEval(input)
+	result, ok := evaluated.(*object.Integer)
+	if !ok {
+		t.Fatalf("expected result to be of type *object.Integer. Got %T instead.", evaluated)
+	}
+
+	if !testIntegerObject(t, result, 10) {
+		return
 	}
 }
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -67,6 +67,7 @@ func TestNextToken(t *testing.T) {
 	"foo bar";
 	[1, 2];
 	{"foo": "bar"}
+	while (x < 5) { x; }
 	# Will a comment work at the end??
 	`
 	tests := []struct {
@@ -177,6 +178,17 @@ func TestNextToken(t *testing.T) {
 		{token.STRING, "foo"},
 		{token.COLON, ":"},
 		{token.STRING, "bar"},
+		{token.RBRACE, "}"},
+		// while (x < 5) { x; }
+		{token.WHILE, "while"},
+		{token.LPAREN, "("},
+		{token.IDENT, "x"},
+		{token.LT, "<"},
+		{token.INT, "5"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.SEMICOLON, ";"},
 		{token.RBRACE, "}"},
 		// EOF
 		{token.EOF, ""},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -63,6 +63,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 	p.registerPrefix(token.IF, p.parseIfExpression)
+	p.registerPrefix(token.WHILE, p.parseWhileExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	// Register infix parsers
@@ -282,6 +283,25 @@ func (p *Parser) parseIfExpression() ast.Expression {
 		expression.Alternative = p.parseBlockStatement()
 	}
 
+	return expression
+}
+
+func (p *Parser) parseWhileExpression() ast.Expression {
+	expression := &ast.WhileExpression{Token: p.currentToken}
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	expression.Condition = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+
+	expression.Body = p.parseBlockStatement()
 	return expression
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -494,6 +494,45 @@ func TestIfElseExpression(t *testing.T) {
 	}
 }
 
+func TestWhileExpression(t *testing.T) {
+	input := "while (x < y) { x; }"
+	lex := lexer.New(input)
+	pars := New(lex)
+	program := pars.ParseProgram()
+	checkForParserErrors(t, pars)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("Expected program to have 1 statement. Got %d", len(program.Statements))
+	}
+
+	statement, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Expected program statement to be an expression statement. Got %T", program.Statements[0])
+	}
+
+	expr, ok := statement.Expression.(*ast.WhileExpression)
+	if !ok {
+		t.Fatalf("Expected statement expression to be of type *ast.WhileExpression. Got %T", statement.Expression)
+	}
+
+	if !testInfixExpression(t, expr.Condition, "x", "<", "y") {
+		return
+	}
+
+	if len(expr.Body.Statements) != 1 {
+		t.Errorf("Expected loop body to have 1 statement. Got %d", len(expr.Body.Statements))
+	}
+
+	body, ok := expr.Body.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Expected body statement to be of type *ast.ExpressionStatement")
+	}
+
+	if !testIdentifier(t, body.Expression, "x") {
+		return
+	}
+}
+
 func TestFunctionLiteralExpression(t *testing.T) {
 	input := "fn(x, y) { x + y; }"
 	lex := lexer.New(input)

--- a/token/token.go
+++ b/token/token.go
@@ -14,6 +14,7 @@ var keywords = map[string]TokenType{
 	"false":  FALSE,
 	"if":     IF,
 	"else":   ELSE,
+	"while":  WHILE,
 	"return": RETURN,
 }
 
@@ -60,5 +61,6 @@ const (
 	FALSE    = "FALSE"
 	IF       = "IF"
 	ELSE     = "ELSE"
+	WHILE    = "WHILE"
 	RETURN   = "RETURN"
 )


### PR DESCRIPTION
closes #6 

Adds `while` loop syntax to Monkey with some sanity checking tests and an error for overly long loops.

Loop syntax looks like this:
```js
let i = 0;
while (i < 100) {
  print(i);
  let i = i + 1;
};
```

`while` always returns `null`.


Note: this PR also changes `log.Println()` inside of the builtin function `print()` to `fmt.Println()`. This is because log appends timestamps.